### PR TITLE
fix / 이력서 저장 없이 페이지 이탈 시 팝업 추가

### DIFF
--- a/src/components/ConfirmModal.module.css
+++ b/src/components/ConfirmModal.module.css
@@ -1,0 +1,75 @@
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.modal {
+  background: white;
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.modalTitle {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--n-900);
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.modalMessage {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--n-700);
+  text-align: center;
+  line-height: 1.5;
+  margin-bottom: 24px;
+}
+
+.modalButtons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.modalCancel,
+.modalConfirm {
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-size: 17px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+  min-width: 148px;
+  min-height: 54px;
+}
+
+.modalCancel {
+  background-color: var(--n-200);
+  color: var(--n-800);
+}
+
+.modalCancel:hover {
+  background-color: var(--n-300);
+}
+
+.modalConfirm {
+  background-color: var(--primaryjogak-1);
+  color: white;
+}
+
+.modalConfirm:hover {
+  background-color: var(--primarymain-800);
+}

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React from 'react';
+import styles from './ConfirmModal.module.css';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title?: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+export function ConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title = '확인',
+  message = '',
+  confirmText = '확인',
+  cancelText = '취소',
+}: Props) {
+  if (!isOpen) return null;
+
+
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modal}>
+        <h3 className={styles.modalTitle}>{title}</h3>
+        <p className={styles.modalMessage}>
+          {message.split('\n').map((line, index) => (
+            <React.Fragment key={index}>
+              {line}
+              {index < message.split('\n').length - 1 && <br />}
+            </React.Fragment>
+          ))}
+        </p>
+        <div className={styles.modalButtons}>
+          <button
+            className={styles.modalCancel}
+            onClick={onClose}
+          >
+            {cancelText}
+          </button>
+          <button
+            className={styles.modalConfirm}
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 관련이슈
#8 

## 변경내용
- ConfirmModal 추가
- resume/create 페이지에 ConfirmModal 추가

---
- 이력서 내용 변경 후 `<-` 버튼 누를 시 모달 발생
- 새로고침 시에도 브라우저 알림 발생
- 이력서 첫 등록 시에도 똑같이 작동
- 이력서 내용 변경 없으면 페이지 이탈 시 알림 모달 없이 그대로 이동

<img width="2548" height="1284" alt="스크린샷 2025-08-06 오후 12 09 40" src="https://github.com/user-attachments/assets/c0f34e04-505e-4709-8437-647c7ca802c5" />
<img width="2548" height="1284" alt="스크린샷 2025-08-06 오후 12 10 00" src="https://github.com/user-attachments/assets/953d59a5-9356-4dba-b8bb-0ebc798cde37" />
<img width="2548" height="1284" alt="스크린샷 2025-08-06 오후 12 11 50" src="https://github.com/user-attachments/assets/3700f478-c308-4836-b322-6930570fb73a" />

