### PR TITLE
fix / 페이지 이동 수정

### DIFF
--- a/src/app/job/create/page.tsx
+++ b/src/app/job/create/page.tsx
@@ -80,7 +80,7 @@ export default function CreateJobPage() {
 
   const handleCompleteAnimationEnd = () => {
     if (nextJdId) {
-      router.push(`/job/${nextJdId}`);
+      router.replace(`/job/${nextJdId}`);
     }
   };
 

--- a/src/app/resume/create/page.tsx
+++ b/src/app/resume/create/page.tsx
@@ -171,7 +171,7 @@ function ResumeCreateContent() {
             ? '이력서가 성공적으로 수정되었습니다.'
             : '이력서가 성공적으로 등록되었습니다.'
         );
-        router.push('/dashboard');
+        router.replace(resumeId ? `/dashboard` : '/job/create');
       } else if (response.status === 409) {
         setContentErrorMessage({
           modalTitle: '이력서 등록 오류',


### PR DESCRIPTION
## 관련 이슈
- #24 
## 변경 사항
- 첫 이력서 등록 후 router.push -> router.replace로 채용공고 추가페이지로 이동
- 첫 이력서 등록 후 채용공고 등록 페이지로 이동
채용 공고 등록 후 뒤로가기 시 대시보드로 갈 수 있게 수정